### PR TITLE
#4 | Notification system

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,8 @@
 REPO_GITHUB=owner/repo-name
 TOKEN_GITHUB=your_personal_access_token
+EMAIL_HOST=email_provider_host
+EMAIL_PORT=email_provider_port
+EMAIL_USERNAME=your_email
+EMAIL_PASSWORD=your_email_password
+EMAIL_SENDER=your_sending_email
+EMAIL_RECEIVER=your_email_to_be_notified

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 pytest
 python-dotenv
+smtplib


### PR DESCRIPTION
## #4 Implement Notification System for Workflow Failures
- Implemented send_failure_notification using smtplib to send a notification whenever last workflow status is one of the following: `failure`, `timed_out` or `action_required` 5fbb65698a0901c7a4b6796cd9853ec2d92d23e4 | 8dc5288785414ad0cf68c73c99e6fc84ae6dcd62
- Added the following environment variables to configure smtplib:
  - EMAIL_HOST
  - EMAIL_PORT
  - EMAIL_USERNAME
  - EMAIL_PASSWORD
  - EMAIL_SENDER
  - EMAIL_RECEIVER

See the following article as an example on how to get the needed values: https://mailtrap.io/blog/outlook-smtp/